### PR TITLE
Make path to the config.txt file configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ boot_config:
 	gpu_mem: '196'
 ```
 
+**rpi\_boot\_config\_file**, optional
+
+Path of the Raspberry Pi boot configuration file to manage, default: `/boot/config.txt`. Example:
+
+```
+rpi_boot_config_file: /boot/config.txt
+```
 
 ## Dependencies
 
@@ -56,6 +63,7 @@ None.
 * upgraded CI tests to use python3.7+
 * upgraded molecule to version 3.x
 * drop support for ansible 2.8
+* add configurable path to boot config file
 
 ### 4.0.0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,9 @@
 ---
 # defaults for rpi-boot-config
 
+# Path to the Raspberry Pi boot configuration file
+rpi_boot_config_file: /boot/config.txt
+
 boot_config: {}
 #  gpu_mem: 64
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,23 +1,23 @@
 ---
 # tasks file for rpi_boot_config
-- name: "adjust /boot/config.txt based on boot_config"
+- name: "adjust {{ rpi_boot_config_file }} based on boot_config"
   lineinfile:
     line: '{{ item.key }}={{ item.value }}'
-    dest: /boot/config.txt
+    dest: "{{ rpi_boot_config_file }}"
     regexp: "^{{ item.key }}="
   with_dict: '{{ boot_config }}'
   register: _boot_config
 
-- name: "adjust /boot/config.txt based on boot_config_lines"
+- name: "adjust {{ rpi_boot_config_file }} based on boot_config_lines"
   lineinfile:
     line: '{{ item }}'
-    dest: /boot/config.txt
+    dest: "{{ rpi_boot_config_file }}"
     regexp: "^{{ item }}"
   with_items: '{{ boot_config_lines }}'
   register: _boot_config_lines
 
 - name: "restart machine"  # noqa 503
   reboot:
-    msg: "Reboot by Ansible, because /boot/config.txt config changed."
+    msg: "Reboot by Ansible, because {{ rpi_boot_config_file }} config changed."
     reboot_timeout: 300   # (= 5 minutes)
   when: _boot_config.changed or _boot_config_lines.changed


### PR DESCRIPTION
The `config.txt` file, that's loaded as part of the boot process of
Raspberry Pi's, resides in the same directory as the firmware files
and kernel.
Raspberry Pi OS mounts this path at `/boot`, as do many others. However
some distributions use a different path. For example Debian for the
Raspberry Pi (https://raspi.debian.net) uses `/boot/firmware`.

This commit adds variable `rpi_boot_config_file` to allow users to
specify where `config.txt` is located on their device/distribution.